### PR TITLE
add check OS function

### DIFF
--- a/plugin/noraTutor.vim
+++ b/plugin/noraTutor.vim
@@ -11,10 +11,17 @@
 
 let s:filedir = fnamemodify(resolve(expand('<sfile>:p')), ':p:h')
 let s:filedir = strcharpart(s:filedir,0,len(s:filedir)-6)
-if s:filedir !~ '\\$'
-  let s:filedir .= '\'
+
+if has('win32')
+  let s:separator = '\'
+else
+  let s:separator = '/'
 endif
-let s:filedir .= 'tutor\'
+
+if s:filedir !~ '\\$'
+  let s:filedir .= s:separator
+endif
+let s:filedir .= 'tutor'.s:separator
 let s:tutorfile = s:filedir.'tutor.txt'
 let s:tutorcopy = s:filedir.'tutorcopy.txt'
 


### PR DESCRIPTION
Windows固有のパス区切り文字のためにLinuxで機能しないので、OSごとに区切り文字を変更して対応する機能を追加。